### PR TITLE
reducing array accesses for gas optimization

### DIFF
--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -70,14 +70,15 @@ library CommandBuilder {
                     free += stateData.length - 32;
                     unchecked{count += 32;}
                 } else {
-                    uint256 arglen = state[idx & IDX_VALUE_MASK].length;
+                    bytes memory stateVar = state[idx & IDX_VALUE_MASK];
+                    uint256 arglen = stateVar.length;
 
                     // Variable length data; put a pointer in the slot and write the data at the end
                     assembly {
                         mstore(add(add(ret, 36), count), free)
                     }
                     memcpy(
-                        state[idx & IDX_VALUE_MASK],
+                        stateVar,
                         0,
                         ret,
                         free + 4,
@@ -88,9 +89,9 @@ library CommandBuilder {
                 }
             } else {
                 // Fixed length data; write it directly
-                bytes memory statevar = state[idx & IDX_VALUE_MASK];
+                bytes memory stateVar = state[idx & IDX_VALUE_MASK];
                 assembly {
-                    mstore(add(add(ret, 36), count), mload(add(statevar, 32)))
+                    mstore(add(add(ret, 36), count), mload(add(stateVar, 32)))
                 }
                 unchecked{count += 32;}
             }


### PR DESCRIPTION
Issue 10 fixed. Although not exactly as recommended. The stateVar variable, when set for all branches causes runtime error in tests. So was only consolidated for the first 2 branches and passes tests, saving gas.

Copied from: https://github.com/weiroll/weiroll/pull/81